### PR TITLE
Resolve unrendered latex references

### DIFF
--- a/book/linsys/lu.md
+++ b/book/linsys/lu.md
@@ -125,7 +125,7 @@ LU factorization reduces any linear system to two triangular ones. From this, so
 1. Solve $\mathbf{L}\mathbf{z}=\mathbf{b}$ for $\mathbf{z}$ using forward substitution.
 1. Solve $\mathbf{U}\mathbf{x}=\mathbf{z}$ for $\mathbf{x}$ using backward substitution.
 
-One of the important aspects of this algorithm is that the factorization step depends only on the matrix $\mathbf{A}$; the right-hand side $\mathbf{b}$ is not involved. Thus if one has to solve multiple systems with a single matrix $\mathbf{A}$, the factorization needs to be performed only once for all systems. As we show in \secref{opcount}, the factorization is by far the most computationally expensive step, so this note is of more than academic interest.
+One of the important aspects of this algorithm is that the factorization step depends only on the matrix $\mathbf{A}$; the right-hand side $\mathbf{b}$ is not involved. Thus if one has to solve multiple systems with a single matrix $\mathbf{A}$, the factorization needs to be performed only once for all systems. As we show in [a later section](efficiency), the factorization is by far the most computationally expensive step, so this note is of more than academic interest.
 
 Based on the examples and discussion above, a code for LU factorization is given in {ref}`function-lufact`.
 

--- a/book/localapprox/interpolation.md
+++ b/book/localapprox/interpolation.md
@@ -21,7 +21,7 @@ The values $t_0,\ldots,t_n$ are called the {term}`nodes` of the interpolant. In 
 {doc}`demos/interp-global`
 ````
 
-Polynomials are the obvious first candidate to serve as interpolating functions. They are easy to work with, and in \secref{linsysinterp} we saw that a linear system of equations can be used to determine the coefficients of a polynomial that passes through every member of a set of given points in the plane. However, it's not hard to find examples for which polynomial interpolation leads to unusable results.
+Polynomials are the obvious first candidate to serve as interpolating functions. They are easy to work with, and in [a previous section](../linsys/polyinterp) we saw that a linear system of equations can be used to determine the coefficients of a polynomial that passes through every member of a set of given points in the plane. However, it's not hard to find examples for which polynomial interpolation leads to unusable results.
 
 ```{margin}
 Interpolation by a polynomial at equally spaced nodes is ill-conditioned as the degree of the polynomial grows.

--- a/book/nonlineqn/newton.md
+++ b/book/nonlineqn/newton.md
@@ -105,7 +105,7 @@ Let's revisit the assumptions made to derive quadratic convergence as given by {
 2. We required $f'(r)\neq 0$---that is, $r$ must be a *simple* root. See [this exercise](problem-newtonmultiple) to investigate what happens at a multiple root.
 3. We assumed that the sequence converged, which is not easy to guarantee in any particular case. In fact,
 finding a starting guess from which the Newton iteration converges is
-often the most challenging part of a rootfinding problem. We will try to deal with this issue in \secref{quasinewton}.
+often the most challenging part of a rootfinding problem. We will try to deal with this issue in [a later section](quasinewton).
 
 ## Implementation
 

--- a/book/nonlineqn/quasinewton.md
+++ b/book/nonlineqn/quasinewton.md
@@ -33,7 +33,7 @@ In the system case, replacing the Jacobian evaluation is more complicated: deriv
 
 For reasons explained in the next chapter, $\delta$ is usually chosen close to $\sqrt{\epsilon}$, where $\epsilon$ represents the expected noise level in evaluation of $\mathbf{f}$. If the only source of noise is floating-point roundoff, then $\delta=\sqrt{\epsilon_\text{mach}}$.
 
-The finite-difference formula {eq}`jacobianfd` is implemented by the short code {ref}`function-fdjac`. (The code is written to accept the case where $\mathbf{f}$ maps $n$ variables to $m$ values with $m\neq n$, in anticipation of \secref{nl-least-sq}.)
+The finite-difference formula {eq}`jacobianfd` is implemented by the short code {ref}`function-fdjac`. (The code is written to accept the case where $\mathbf{f}$ maps $n$ variables to $m$ values with $m\neq n$, in anticipation of [a later section](nlsq).)
 
 (function-fdjac)=
 


### PR DESCRIPTION
Hi,

The online textbook seems to contain several latex-style references that were not properly resolved and were left as plain text after rendering. 

For example: 
<img width="831" alt="image" src="https://user-images.githubusercontent.com/41782470/223151697-ccf2195a-fdec-4b95-b7ee-6183b6890d52.png">

I resolve these references into markdown based on the print version of the book, which can therefore be rendered properly. 

Hopefully this helps!