### PR TITLE
Fixed a few notational discrepancies in Chap 6

### DIFF
--- a/chapter6/adaptive-rk.md
+++ b/chapter6/adaptive-rk.md
@@ -64,7 +64,7 @@ Many details remain unspecified at this point, but we first address step 1.
 
 ## Embedded formulas
 
-Suppose, for example, we choose to use a pair of second- and third-order RK methods to get the $\mathbf{u}_{i+1}$ and $\tilde{\mathbf{u}}_{i+1}$ needed in {numref}`Algorithm {number} <algorithm-adaptive-adapt>`. Then we seem to need at least $2+3=5$ evaluations of $f(t,y)$ for each attempted time step. This is more than double the computational work needed by the second-order method without adaptivity.
+Suppose, for example, we choose to use a pair of second- and third-order RK methods to get the $\mathbf{u}_{i+1}$ and $\tilde{\mathbf{u}}_{i+1}$ needed in {numref}`Algorithm {number} <algorithm-adaptive-adapt>`. Then we seem to need at least $2+3=5$ evaluations of $f(t,u)$ for each attempted time step. This is more than double the computational work needed by the second-order method without adaptivity.
 
 Fortunately, the marginal cost of adaptivity can be substantially reduced by using **embedded Runge–Kutta** formulas. Embedded RK formulas are a pair of RK methods whose stages share the same internal $f$ evaluations, combining them differently in order to get estimates of two different orders of accuracy.
 

--- a/chapter6/implicit.md
+++ b/chapter6/implicit.md
@@ -81,7 +81,7 @@ The implementation of an implicit multistep method is more difficult. Consider t
 
 ```{math}
 :label: AM2solve
-  \mathbf{z} - \tfrac{1}{2} h f(t_{i+1},\mathbf{z})  = \mathbf{u}_i + \tfrac{1}{2} h \mathbf{f}(t_i,\mathbf{u}_i)
+  \mathbf{z} - \tfrac{1}{2} h \mathbf{f}(t_{i+1},\mathbf{z})  = \mathbf{u}_i + \tfrac{1}{2} h \mathbf{f}(t_i,\mathbf{u}_i)
 ```
 
 for $\mathbf{z}$. This equation can be written as $\mathbf{g}(\mathbf{z})=\boldsymbol{0}$, so the rootfinding methods of Chapter 4 can be used. The new value $\mathbf{u}_{i+1}$ is equal to the root of this equation.  

--- a/chapter6/rk.md
+++ b/chapter6/rk.md
@@ -141,7 +141,7 @@ A generic $s$-stage RK method takes the form
     &\vdots\\
     k_s &= h f(t_i + c_{s-1}h, u_i + a_{s-1,1}k_1 + \cdots +
     a_{s-1,s-1}k_{s-1}),\\
-    \mathbf{u}_{i+1} &= u_i + b_1k_1 + \cdots + b_s k_s.
+    u_{i+1} &= u_i + b_1k_1 + \cdots + b_s k_s.
   \end{split}
 ```
 

--- a/chapter6/zerostability.md
+++ b/chapter6/zerostability.md
@@ -17,7 +17,7 @@ It is straightforward to check that the two-step method LIAF, defined by
 
 ```{math}
 :label: LIAF
-  \mathbf{u}_{i+1} = -4u_i + 5u_{i-1} + h(4f_i + 2f_{i-1}),
+  u_{i+1} = -4u_i + 5u_{i-1} + h(4f_i + 2f_{i-1}),
 ```
 
 is third-order accurate. Let's apply it to the ridiculously simple IVP $u'=u$, $u(0)=1$, whose solution is $e^t$.


### PR DESCRIPTION
@tobydriscoll Hi Professor Driscoll. This semester I taught a hybrid numerical analysis and numerical linear algebra using your book. I like the book a lot. My students and I noticed a typo and several notational discrepancies.

The typo I noticed when going through Example 6.6.4 during class was already fixed in c795479 last week. Here are some `\mathbf{}` vs regular font discrepancies in Chap 6. 

BTW: Is there a specific reason to use $\hat{u}(t_i)$ not $u(t_i)$ to denote the true solution across Chap 6?