### PR TITLE
Fix: potential out-of-bounds in newton() and secant()

### DIFF
--- a/python/pkg/FNC/FNC04.py
+++ b/python/pkg/FNC/FNC04.py
@@ -15,7 +15,7 @@ def newton(f, dfdx, x1):
     xtol = 100 * eps
     maxiter = 40
 
-    x = np.zeros(maxiter)
+    x = np.zeros(maxiter + 1)
     x[0] = x1
     y = f(x1)
     dx = np.inf  # for initial pass below
@@ -47,7 +47,7 @@ def secant(f, x1, x2):
     xtol = 100 * eps
     maxiter = 40
 
-    x = np.zeros(maxiter)
+    x = np.zeros(maxiter + 1)
     x[:2] = [x1, x2]
     y1 = f(x1)
     y2 = 100

--- a/separate/python/chapter4/chapter04.py
+++ b/separate/python/chapter4/chapter04.py
@@ -15,7 +15,7 @@ def newton(f, dfdx, x1):
     xtol = 100 * eps
     maxiter = 40
 
-    x = np.zeros(maxiter)
+    x = np.zeros(maxiter + 1)
     x[0] = x1
     y = f(x1)
     dx = np.inf  # for initial pass below
@@ -47,7 +47,7 @@ def secant(f, x1, x2):
     xtol = 100 * eps
     maxiter = 40
 
-    x = np.zeros(maxiter)
+    x = np.zeros(maxiter + 1)
     x[:2] = [x1, x2]
     y1 = f(x1)
     y2 = 100


### PR DESCRIPTION
Hello, `newton()` and `secant()` in Chapter 4 both initialize the iteration history using `x = np.zeros(maxiter)`. However, if the algorithm fails to converge, `x[k + 1] = x[k] + dx` with the loop condition `k < maxiter` will cause out-of-bounds.

This is fixed by changing `x = np.zeros(maxiter)` to `x = np.zeros(maxiter + 1)`.

```python

def newton(f, dfdx, x1):
    """
    newton(f, dfdx, x1)

    Use Newton's method to find a root of f starting from x1, where dfdx is the
    derivative of f. Returns a vector of root estimates.
    """
    # Operating parameters.
    eps = np.finfo(float).eps
    funtol = 100 * eps
    xtol = 100 * eps
    maxiter = 40

    x = np.zeros(maxiter) # Change to x = np.zeros(maxiter + 1)
    x[0] = x1
    y = f(x1)
    dx = np.inf  # for initial pass below
    k = 0

    while (abs(dx) > xtol) and (abs(y) > funtol) and (k < maxiter):
        dydx = dfdx(x[k])
        dx = -y / dydx  # Newton step
        x[k + 1] = x[k] + dx  # new estimate

        k = k + 1
        y = f(x[k])

    if k == maxiter:
        warnings.warn("Maximum number of iterations reached.")

    return x[: k + 1]
```