### PR TITLE
Fix: Exercise 4.6.7 lambda's inconsistency with the Levenberg's method

### DIFF
--- a/chapter4/quasinewton.md
+++ b/chapter4/quasinewton.md
@@ -347,7 +347,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\lambda^2 \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/chapter4/quasinewton.md
+++ b/chapter4/quasinewton.md
@@ -347,7 +347,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/chapter4/quasinewton.md
+++ b/chapter4/quasinewton.md
@@ -342,12 +342,12 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 
 ``````{exercise}
 :label: problem-quasinewton-penalty
-✍ Show that Equation {eq}`levenberg` is equivalent to the linear least-squares problem
+✍ Show that for $\lambda>0$, Equation {eq}`levenberg` is equivalent to the linear least-squares problem
 
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\lambda \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/julia/chapter4/quasinewton.md
+++ b/separate/julia/chapter4/quasinewton.md
@@ -369,7 +369,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\lambda^2 \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/julia/chapter4/quasinewton.md
+++ b/separate/julia/chapter4/quasinewton.md
@@ -364,12 +364,12 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 
 ``````{exercise}
 :label: problem-quasinewton-penalty
-✍ Show that Equation {eq}`levenberg` is equivalent to the linear least-squares problem
+✍ Show that for $\lambda>0$, Equation {eq}`levenberg` is equivalent to the linear least-squares problem
 
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\lambda \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/julia/chapter4/quasinewton.md
+++ b/separate/julia/chapter4/quasinewton.md
@@ -369,7 +369,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/matlab/chapter4/quasinewton.md
+++ b/separate/matlab/chapter4/quasinewton.md
@@ -338,7 +338,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\lambda^2 \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/matlab/chapter4/quasinewton.md
+++ b/separate/matlab/chapter4/quasinewton.md
@@ -338,7 +338,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/matlab/chapter4/quasinewton.md
+++ b/separate/matlab/chapter4/quasinewton.md
@@ -333,12 +333,12 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 
 ``````{exercise}
 :label: problem-quasinewton-penalty
-✍ Show that Equation {eq}`levenberg` is equivalent to the linear least-squares problem
+✍ Show that for $\lambda>0$, Equation {eq}`levenberg` is equivalent to the linear least-squares problem
 
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\lambda \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/python/chapter4/quasinewton.md
+++ b/separate/python/chapter4/quasinewton.md
@@ -363,12 +363,12 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 
 ``````{exercise}
 :label: problem-quasinewton-penalty
-✍ Show that Equation {eq}`levenberg` is equivalent to the linear least-squares problem
+✍ Show that for $\lambda>0$, Equation {eq}`levenberg` is equivalent to the linear least-squares problem
 
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\lambda \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/python/chapter4/quasinewton.md
+++ b/separate/python/chapter4/quasinewton.md
@@ -368,7 +368,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+\bigl|\lambda\bigr| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)

--- a/separate/python/chapter4/quasinewton.md
+++ b/separate/python/chapter4/quasinewton.md
@@ -368,7 +368,7 @@ Let $\mathbf{x}_1=[-2,1]^T$ and let $\mathbf{A}_1=\mathbf{J}(\mathbf{x}_1)$ be t
 ```{math}
 :numbered: false
 \min_{\mathbf{v}} \Bigl(  \bigl\|\mathbf{A}_k\mathbf{v} + \mathbf{f}_k\bigr\|_2^2 +
-\lambda^2 \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
+|\lambda| \bigl\| \mathbf{v} \bigr\|_2^2 \Bigr).
 ```
 
 (Hint: Express the least-squares residual using block matrix notation, such that {eq}`levenberg` becomes the normal equations for it.)


### PR DESCRIPTION
Hello, in [Exercise 4.6.7](https://fncbook.com/quasinewton/#problem-quasinewton-penalty), $\lambda^2$ need to be changed to $|\lambda|$ to keep consistency with the Levenberg's method defined by the Equation 4.6.9. $A^TA+\lambda I$ becomes the matrix multiplication of $[A^T\ \sqrt{\lambda}I_n ]$ and its transpose. By extracting $\sqrt{\lambda}$ from the squared 2-norm, we get $|\lambda|$ rather than $\lambda^2$.

<img width="1109" height="419" alt="截屏2026-06-28 22 37 34" src="https://github.com/user-attachments/assets/5d61a7a2-bbb6-45df-b5dd-28a46d0f24cf" />

Here is my solution for that.

<img width="3024" height="4032" alt="tempImagef0hwvJ" src="https://github.com/user-attachments/assets/7bdbcdbf-aa54-4dff-b615-a9cb86068224" />


